### PR TITLE
fixed show switches command

### DIFF
--- a/apps/mn-ctl/main.go
+++ b/apps/mn-ctl/main.go
@@ -374,7 +374,7 @@ func main() {
 
 			if commands[1] == "switches" {
 				for _, node := range scheme.Switches {
-					fmt.Println(node.NodeName)
+					fmt.Println(node.NodeName())
 				}
 			}
 		}


### PR DESCRIPTION
Changed file main.go in open-mininet/apps/mn-ctl

changed function main() -> case show: -> switches
from fmt.Println(node.NodeName) to fmt.Println(node.NodeName())

Now show switches shows switch names instead of memory address

